### PR TITLE
 Add an environment variable for CRAFT_SECURITY_KEY

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,4 @@ services:
       - DATABASE_URL=mysql://root:somegloriouspassword@database:3306/craft_cms
       - APACHE_DOCUMENT_ROOT=/var/www/html/web
       - REDIS_URL=redis://redis_service:6379
+      - CRAFT_SECURITY_KEY='RoFpqDtm-V-_OaxGsChUCvM6hewpHNRa'


### PR DESCRIPTION
Add an environment variable for CRAFT_SECURITY_KEY to docker-compose.yml because I was unable to run craft in docker without it.