### PR TITLE
Set php max execution time to 120s as Craft CMS recommends.

### DIFF
--- a/docker-src/src/php.ini
+++ b/docker-src/src/php.ini
@@ -1,3 +1,4 @@
 html_errors = on
 log_errors = on
 memory_limit = 256M
+max_execution_time = 120


### PR DESCRIPTION
I noticed that the Craft CMS dashboard complained about low execution time, it should be at least 120s to allow for long running composer jobs. Source: https://craftcms.com/guides/php-ini