### PR TITLE
Feature improve docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - "5000:80"
     volumes:
       - ./:/var/www/html/:cached
+      - ./storage/:/var/www/html/storage/:delegated
     environment:
       - DATABASE_URL=mysql://root:somegloriouspassword@database:3306/craft_cms
       - APACHE_DOCUMENT_ROOT=/var/www/html/public

--- a/docker-src/Dockerfile
+++ b/docker-src/Dockerfile
@@ -8,7 +8,7 @@ RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf
 # Install dependencies required by php-extensions
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl git zip \
   libc-client-dev libkrb5-dev libpng-dev libmagickwand-dev \
-  libmemcached-dev libicu-dev \
+  libmemcached-dev libicu-dev default-mysql-client \
   # deps needed for mcrypt
   gcc make autoconf libc-dev pkg-config libmcrypt-dev
 


### PR DESCRIPTION
The Dockerfile was missing default-mysql-client package which made backups unavailable on localhost. Also. Improved docker speed by using [delegated flag](https://docs.docker.com/docker-for-mac/osxfs-caching/#delegated).