### PR TITLE
Fix matrix field max_input_vars issue by upping the var in php.ini

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     volumes:
       - ./:/var/www/html/
       - ./storage/:/var/www/html/storage/:delegated
+      - ./docker-src/src/php.ini:/usr/local/etc/php/php.ini
     environment:
       - DATABASE_URL=mysql://root:somegloriouspassword@database:3306/craft_cms
       - APACHE_DOCUMENT_ROOT=/var/www/html/public

--- a/docker-src/src/php.ini
+++ b/docker-src/src/php.ini
@@ -2,3 +2,4 @@ html_errors = on
 log_errors = on
 memory_limit = 256M
 max_execution_time = 120
+max_input_vars = 5000


### PR DESCRIPTION
Setting max_input_vars to 5000 instead of 1000, to avoid this bug: https://github.com/craftcms/cms/issues/5554