### PR TITLE
add node_env = production in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "echo 'You probably want to $ npm run dev'",
     "dev": "npm run clean && webpack --watch --mode development --progress",
-    "build": "npm run clean && webpack --mode production --progress --devtool source-map",
+    "build": "npm run clean && NODE_ENV=production webpack --mode production --progress --devtool source-map",
     "postinstall": "npm run build",
     "db:arcustech:download": "hamstr mysqldump --tunnel -p docker-src/db-dump/dump.sql prod",
     "docker:rebuild": "docker-compose down && docker-compose up",


### PR DESCRIPTION
For PurgeCSS to automatically remove unused Tailwind classes, NODE_ENV needs to be set to 'production' during build, as mentioned in the [documentation](https://v1.tailwindcss.com/docs/controlling-file-size#removing-unused-css)