### PR TITLE
Update GETTING_STARTED.md

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -12,11 +12,11 @@ _Read through the readme_, and if you are stuck, don't hesitate to ask in either
     - Apache Server, to mirror production environment.
     - Redis, used for caching logins included so that we mirror production.
     - Mysql, the database.
-1.  It might/will take some time for the containers to finish building and there will be no complete message. So, just wait a bit until the text stops flowing and then go to `http://localhost:5000/admin` to install Craft.
+1.  It might/will take some time for the containers to finish building and there will be no complete message. So, just wait a bit until the text stops flowing and then go to [`localhost:5000/admin`](http://localhost:5000/admin) to install Craft.
 
 ### Start livereloading and asset building on localhost:3000
 
-When you have docker-compose running in one terminal window please open a second window where you run `npm run dev`. This will start a process that will be building our frontend dependencies. Our build setup provides a localhost:3000 address that shows the same as localhost:5000 but also has livereloading.
+When you have docker-compose running in one terminal window please open a second window where you run `npm run dev`. This will start a process that will be building our frontend dependencies. Our build setup provides a [`localhost:3000`](http://localhost:3000) address that shows the same as localhost:5000 but also has livereloading.
 
 Edit CSS and JavaScript in the `/resources/`-folder. Webpack will compile, transpile, minify it into the `public` folder, ready for production. If you put files in the assets-folder, Webpack will handle those too (see file-loader).
 
@@ -26,7 +26,7 @@ The file `resources/js/main.js` is built into `public/dist/main.dist.js`, and it
 
 Both files are included in `./templates/_layout.twig`
 
-When you want to login into Craft you'll need to go to localhost:5000/admin, because localhost:3000 is just a livereloading proxy that can't handle logins.
+When you want to login into Craft you'll need to go to [`localhost:5000/admin`](http://localhost:5000/admin), because [`localhost:3000`](http://localhost:3000) is just a livereloading proxy that can't handle logins.
 
 ## Changing the remote git repository
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -59,7 +59,7 @@ Perform the following steps in a terminal: You only need to do this once per lap
 - Start by [installing brew](https://brew.sh/)
 - Run `brew install nvm` for Node version manager.
 - Run `brew install mysql` for the MySQL command line tools.
-- Run `brew cask install docker` for Docker. Open Docker App, so later you can continue in terminal.
+- Run `brew install --cask docker` for Docker. Open Docker App, so later you can continue in terminal.
 
 ### Troubleshooting
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -32,9 +32,8 @@ When you want to login into Craft you'll need to go to localhost:5000/admin, bec
 
 If you have cloned this project, the git remote `origin` is set to the craft-starter repository. Unless you're actually working on improving the craft-starter, you should set the remote `origin` to your project repository.
 
-1.  Remove the current `origin` with `git remote rm origin`
-2.  Add the new origin with `git remote add origin git@github.com:netliferesearch/repository-name`
-3.  Push to the new origin with `git push --set-upstream origin master`
+1.  Update the current `origin` with `git remote set-url origin git@github.com:netliferesearch/repository-name.git`
+2.  Push to the new origin with `git push --set-upstream origin master`
 
 ## Updating composer.json dependencies
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -7,7 +7,7 @@ _Read through the readme_, and if you are stuck, don't hesitate to ask in either
 1.  Clone, or download this repository
 1.  If you haven't already install [global dependencies for the craft-starter](#global-deps).
 1.  Run `npm install` to install NPM dependencies.
-1.  Copy and paste `.env.example` and rename it to `.env` to avoid `Internal server error`
+1.  Run `cp .env.example .env` to avoid `Internal server error`
 1.  Run `docker-compose up` to start three containers (details found in docker-compose.yml):
     - Apache Server, to mirror production environment.
     - Redis, used for caching logins included so that we mirror production.


### PR DESCRIPTION
Quailty of life improvements to `GETTING_STARTED.md`.

- Using built-in copy/past-command, `cp`, since you are already in the terminal, for added efficiency
- Corrected deperacted method for installing brew-casks
- Simplified changing git-remote with one command, instead of two
- Added actual links to `localhost`'s links