### PR TITLE
Add robots.txt and sitemap.xml

### DIFF
--- a/docs/seo.md
+++ b/docs/seo.md
@@ -29,6 +29,9 @@ examples of what it can look like.
         <loc>
           {{ entry.url }}
         </loc>
+        <lastmod>
+          {{ entry.dateUpdated|date('c') }}
+        </lastmod>
       </url>
     {% endfor %}
   {% endfor %}

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -1,0 +1,36 @@
+# SEO in Craft CMS
+
+[SEOmatic](https://plugins.craftcms.com/seomatic) is included in this project by default. It has a straight-forward UI for how to
+set up SEO for sections and globally. It's a paid plugin, but it's usually something we recommend our client to buy since it makes it possible for
+them to update and control some SEO-parameters without a developer.
+
+## Built-in
+
+If a client doesn't want to use/pay for SEOmatic you can create two new files in
+your templates-directory, for `robots.txt` and `sitemap.xml`. These are simple
+examples of what it can look like.
+
+### `robots.txt`
+
+```twig
+{% header 'Content-Type: text/plain; charset=utf-8' %}User-agent: * Disallow:
+/admin/{% if getenv('CRAFT_ENVIRONMENT') == 'production' %}
+  Allow: /
+{% endif %}
+```
+
+### `sitemap.xml`
+
+```twig
+<urlset>
+  {% for section in craft.app.sections.getAllSections() %}
+    {% for entry in craft.entries.sectionId(section.id).limit(null).all() %}
+      <url>
+        <loc>
+          {{ entry.url }}
+        </loc>
+      </url>
+    {% endfor %}
+  {% endfor %}
+</urlset>
+```


### PR DESCRIPTION
Added SEO examples for `sitemap.xml` and `robots.txt` (fixes #40).

These are good starters for new projects that don't use a plugin for these. Sitemap could be used as a way to check every page, and verify that they do not contain any bugs or are missing something.
